### PR TITLE
[FIX] test_flake8: Use TRAVIS_BUILD_DIR folder. Before 'current directory': with local environment don't work fine.

### DIFF
--- a/travis/test_flake8
+++ b/travis/test_flake8
@@ -3,9 +3,10 @@
 set -v
 
 FLAKE8_CONFIG_DIR="$(dirname $0)/cfg"
+MODULES_TO_TEST=$TRAVIS_BUILD_DIR
 
-flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8__init__.cfg
+flake8 ${MODULES_TO_TEST} --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8__init__.cfg
 status1=$?
-flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8.cfg
+flake8 ${MODULES_TO_TEST} --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8.cfg
 status2=$?
 exit $((${status1} || ${status2}))

--- a/travis/test_flake8
+++ b/travis/test_flake8
@@ -3,7 +3,7 @@
 set -v
 
 FLAKE8_CONFIG_DIR="$(dirname $0)/cfg"
-MODULES_TO_TEST=$TRAVIS_BUILD_DIR
+MODULES_TO_TEST=${TRAVIS_BUILD_DIR}
 
 flake8 ${MODULES_TO_TEST} --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8__init__.cfg
 status1=$?


### PR DESCRIPTION
Before:
Execute flake8 in current folder.
travis and shippable use current folder equal to TRAVIS_BUILD_DIR
However, if I use a docker local and execute script `test_flake8`this will use local path and check all folder and subfolder.
We need that the result of test flake8 is consistent like as pylint script:
[pylint_with_travis_build_dir](https://github.com/Vauxoo/maintainer-quality-tools/blob/master/travis/test_pylint#L5)

Now:
With this change the environment variable: TRAVIS_BUILD_DIR always is used in flake8 test.