### PR TITLE
[FIX] travis_install_nghtly: Get pylint configuration file of vauxoo in lint env enabled and small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ env:
   - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
   # - VERSION="6.1" INCLUDE="test_module,second_module"
   - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="25" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
-  - VERSION="master" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="58" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
-  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="47" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+  - VERSION="master" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="60" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
+  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="49" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -22,7 +22,7 @@ def get_extra_params(odoo_version):
     :param version: String with name of version of odoo
     :return: List of extra pylint params
     '''
-    params = ["--load-plugins=pylint_oca"]
+    params = ["--load-plugins=pylint_odoo"]
     odoo_version = odoo_version.replace('.', '')
     custom_cfg = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -8,7 +8,7 @@ if [ "${LINT_CHECK}" != "0" ]; then
     wget -q https://raw.githubusercontent.com/moylop260/pylint-oca/master/requirements.txt -O ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
     find -L ${HOME}/maintainer-quality-tools/travis -name pylint_odoo_requirements.txt -exec sed -i '/lxml/d'  {} \;  #  lxml depends is too slow
     pip install --upgrade -r ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
-    pip install --upgrade --pre --no-deps git+https://github.com/moylop260/pylint_oca.git   # To test last developer version ever
+    pip install --upgrade --pre --no-deps git+https://github.com/vauxoo/pylint-odoo.git   # To test last developer version ever
     npm install -g jshint  # To oca-pylint-plugin
     # First install show error and second time install fine!
     npm install -g jshint  # To oca-pylint-plugin

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -10,6 +10,8 @@ if [ "${LINT_CHECK}" != "0" ]; then
     pip install --upgrade -r ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
     pip install --upgrade --pre --no-deps git+https://github.com/moylop260/pylint_oca.git   # To test last developer version ever
     npm install -g jshint  # To oca-pylint-plugin
+    # Get pylint configuration file of vauxoo
+    wget -q https://raw.githubusercontent.com/Vauxoo/pylint-conf/master/conf/pylint_vauxoo_light.cfg -O ${HOME}/maintainer-quality-tools/travis/cfg/travis_run_pylint.cfg
 fi
 
 ## We can exit here and do nothing if this only a LINT check
@@ -96,7 +98,6 @@ pip install --user -q -r $(dirname ${BASH_SOURCE[0]})/requirements.txt
 cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc ${TRAVIS_BUILD_DIR}
 
 $(dirname ${BASH_SOURCE[0]})/shippable_install_nightly
-wget -q https://raw.githubusercontent.com/Vauxoo/pylint-conf/master/conf/pylint_vauxoo_light.cfg -O ${HOME}/maintainer-quality-tools/travis/cfg/travis_run_pylint.cfg
 
 
 # Expected directory structure:

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -10,6 +10,9 @@ if [ "${LINT_CHECK}" != "0" ]; then
     pip install --upgrade -r ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
     pip install --upgrade --pre --no-deps git+https://github.com/moylop260/pylint_oca.git   # To test last developer version ever
     npm install -g jshint  # To oca-pylint-plugin
+    # First install show error and second time install fine!
+    npm install -g jshint  # To oca-pylint-plugin
+    npm install -g jshint  # To oca-pylint-plugin
     # Get pylint configuration file of vauxoo
     wget -q https://raw.githubusercontent.com/Vauxoo/pylint-conf/master/conf/pylint_vauxoo_light.cfg -O ${HOME}/maintainer-quality-tools/travis/cfg/travis_run_pylint.cfg
 fi

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -5,7 +5,7 @@ if [ "${LINT_CHECK}" != "0" ]; then
     pip install -q QUnitSuite flake8 Click
 
     # pylint plugin depends
-    wget -q https://raw.githubusercontent.com/moylop260/pylint-oca/master/requirements.txt -O ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
+    wget -q https://raw.githubusercontent.com/vauxoo/pylint-odoo/master/requirements.txt -O ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
     find -L ${HOME}/maintainer-quality-tools/travis -name pylint_odoo_requirements.txt -exec sed -i '/lxml/d'  {} \;  #  lxml depends is too slow
     pip install --upgrade -r ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
     pip install --upgrade --pre --no-deps git+https://github.com/vauxoo/pylint-odoo.git   # To test last developer version ever
@@ -15,6 +15,7 @@ if [ "${LINT_CHECK}" != "0" ]; then
     npm install -g jshint  # To oca-pylint-plugin
     # Get pylint configuration file of vauxoo
     wget -q https://raw.githubusercontent.com/Vauxoo/pylint-conf/master/conf/pylint_vauxoo_light.cfg -O ${HOME}/maintainer-quality-tools/travis/cfg/travis_run_pylint.cfg
+    wget -q https://raw.githubusercontent.com/Vauxoo/pylint-conf/master/conf/pylint_vauxoo_light_pr.cfg -O ${HOME}/maintainer-quality-tools/travis/cfg/travis_run_pylint_pr.cfg
 fi
 
 ## We can exit here and do nothing if this only a LINT check


### PR DESCRIPTION
- [x] Vauxoo has a custom configuration file pylint but currently It don't is used. (Fixed in this pr)
- [x] Merge after fix all pylint of main current projects
- [x] Migrate of pylint_oca to pylint_odoo
- [x] Download pr configuration file of pylint.
- [x] Fix jshint error when is installed previously.