### PR TITLE
[REF] test_server: Add test-enable optional

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -289,6 +289,7 @@ def main(argv=None):
     instance_alive = str2bool(os.environ.get('INSTANCE_ALIVE'))
     is_runbot = str2bool(os.environ.get('RUNBOT'))
     data_dir = os.environ.get("DATA_DIR", '~/data_dir')
+    test_enable = str2bool(os.environ.get('TEST_ENABLE', True))
     stdout_log = os.environ.get(
         "STDOUT_LOG", os.path.join(os.path.expanduser(data_dir), 'stdout.log'))
     if not os.path.isdir(os.path.dirname(stdout_log)):
@@ -304,7 +305,8 @@ def main(argv=None):
         install_options += ["--test-disable"]
         test_loglevel = 'test'
     else:
-        options += ["--test-enable"]
+        if test_enable:
+            options += ["--test-enable"]
         if odoo_version == '7.0':
             test_loglevel = 'test'
         else:

--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -35,7 +35,8 @@ def print_pstats(sort='cumulative'):
     return True
 
 
-if os.environ.get('TESTS', '0') == '1':
+if os.environ.get('TESTS', '0') == '1' and \
+        os.environ.get('TEST_ENABLE', '1') == '1':
     if print_pstats('cumulative'):
         print_pstats('calls')
         print_pstats('time')


### PR DESCRIPTION
You can use in travis2docker the command:
`TEST_ENABLE=0 /entrypoint.sh`
And you will have a database with all modules installed without run tests.

Fix https://github.com/Vauxoo/maintainer-quality-tools/issues/89