### PR TITLE
[FIX] travis: check enviroment variable ODOO_BRANCH

### DIFF
--- a/travis/travis_weblate.py
+++ b/travis/travis_weblate.py
@@ -61,10 +61,12 @@ def main(argv=None):
     odoo_exclude = os.environ.get("EXCLUDE")
     odoo_include = os.environ.get("INCLUDE")
     odoo_version = os.environ.get("VERSION")
+    odoo_branch = os.environ.get("ODOO_BRANCH")
     langs = parse_list(os.environ.get("LANG_ALLOWED", ""))
 
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
-    server_path = get_server_path(odoo_full, odoo_version, travis_home)
+    server_path = get_server_path(
+        odoo_full, odoo_branch or odoo_version, travis_home)
     addons_path = get_addons_path(travis_home, travis_build_dir, server_path)
     addons_list = get_addons_to_check(travis_build_dir, odoo_include,
                                       odoo_exclude)


### PR DESCRIPTION
Summary
-------------

Before this fix, if we use ODOO_BRANCH parameter the script `travis_weblate.py `fails because the odoo addons path not use odoo version name but use odoo branch name

**Error related:**

![job 182 2 vauxoo worldpromotionals travis ci](https://cloud.githubusercontent.com/assets/5335402/24809551/7a939db6-1b85-11e7-9ab1-e43d9c4e1ec3.png)
