### PR TITLE
[FIX] travis_install_nightly: Adding nvm to .bashrc for autoload

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -3,12 +3,14 @@ set -v
 
 if [ "${LINT_CHECK}" != "0" ]; then
     if [ -f "${HOME}/.nvm/nvm.sh" ]; then
+        echo "Configuring the nvm"
         # Update nodejs v6.latest required by eslint
         # Using nvm of travis
         CURRENT_NODE=$(which node)
         source ${HOME}/.nvm/nvm.sh
         nvm install 6
         ln -sf $(nvm which 6) $CURRENT_NODE
+        echo "source $HOME/.nvm/nvm.sh" >> ${HOME}/.bashrc
     fi
     pip install -q QUnitSuite flake8 Click
 


### PR DESCRIPTION
This PR adding `source $HOME/.nvm/nvm.sh` into `${HOME}/.bashrc` for autoload the `nvm` configuration

![image](https://user-images.githubusercontent.com/1387970/27102269-9937ab0c-5052-11e7-8655-766f6ddd663a.png)

Fix https://github.com/Vauxoo/travis2docker/issues/105