### PR TITLE
[FIX] Fixed cloning and loading dependencies

### DIFF
--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -28,6 +28,7 @@ import os
 import os.path as osp
 import subprocess
 import logging
+from git_update import get_repo_data
 
 
 _logger = logging.getLogger()
@@ -39,7 +40,7 @@ travis_repo_slug = os.environ.get(
 travis_repo_owner = travis_repo_slug.split("/")[0]
 
 
-def parse_depfile(depfile):
+def parse_depfile(depfile, default_owner):
     deps = []
     for line in depfile:
         line = line.strip()
@@ -54,8 +55,10 @@ def parse_depfile(depfile):
         if len(parts) > 1:
             url = parts[1]
         else:
-            url = 'https://github.com/%s/%s' % (travis_repo_owner, repo)
-        deps.append((repo, url, branch))
+            url = 'https://github.com/%s/%s' % (default_owner, repo)
+        repo_data = get_repo_data(url)
+        owner = repo_data.get('owner') or default_owner
+        deps.append((repo, url, branch, owner))
     return deps
 
 
@@ -85,13 +88,15 @@ def run(home, build_dir):
         reqfilename = osp.join(build_dir, repo, 'requirements.txt')
         if osp.isfile(reqfilename):
             reqfilenames.append(reqfilename)
+    dep_owners = {}
     for depfilename in dependencies:
         try:
+            owner = dep_owners.get(depfilename) or travis_repo_owner
             with open(depfilename) as depfile:
-                deps = parse_depfile(depfile)
+                deps = parse_depfile(depfile, owner)
         except IOError:
             deps = []
-        for depname, url, branch in deps:
+        for depname, url, branch, owner in deps:
             _logger.info('* processing %s',  depname)
             if depname in processed:
                 continue
@@ -103,6 +108,7 @@ def run(home, build_dir):
                 reqfilenames.append(reqfilename)
             if new_dep_filename not in dependencies:
                 dependencies.append(new_dep_filename)
+                dep_owners[new_dep_filename] = owner
     for reqfilename in reqfilenames:
         command = ['pip', 'install', '--no-binary', 'pycparser',
                    '-Ur', reqfilename]
@@ -118,6 +124,6 @@ if __name__ == '__main__':
         print(__doc__)
         sys.exit(1)
     else:
-        home = sys.argv[1]
-        build_dir = sys.argv[2]
+        home = osp.expanduser(sys.argv[1])
+        build_dir = osp.expanduser(sys.argv[2])
     run(home, build_dir)


### PR DESCRIPTION
- **Fix 1**: Fixed `clone_oca_dependencies` when repo url is not specified

When cloning the dependencies inside a `oca_dependencies.txt` file that
doesn't have URLs, but only the dependency name...

Before this: the dependencies were cloned by default using the
organization owner of the repository of the build, even when the owner
of the `oca_dependencies.txt` file was different.

Now: if the `oca_dependencies.txt` only specifies the repository name,
the dependencies will be cloned using the same owner as the owner of the
dependencies file.

For example: If you have a repository owned by `vauxoo` organization and
that repo has a dependency of another repo owned by `oca` (like
`stock-logistics-warehouse`) that in turn has an `oca_dependencies.txt`
file with no URLs, those dependencies are going to be gotten from `oca`
as well.

---

- **Fix 2**: Fixed `getaddons.py` to print the repos by dependency level

When loading the addons from a folder to create the `addons_path`...

Before this: the addons are loaded as they are found in the folder, with
no specific order, and no regards for the dependencies.

Now: the addons are loaded following the level of the dependency.

For example: considering `vauxoo/imeqmo` as a base repository, that repo
has a dependency of `vauxoo/stock-logistics-warehouse` which in turn has
a dependency of `vauxoo/stock-logistics-tracking` and
`vauxoo/stock-logistics-barcode` (in that order), the final
`addons_path` will respect their dependency level and will result in
`imeqmo,warehouse,tracking,barcode` (repos paths abbreviated).

---

- Example simulating a build of a repo `vauxoo/imeqmo` having a dependency of `oca/stock-logistics-warehouse`:

![image](https://user-images.githubusercontent.com/8657959/28172007-40136fb6-67b8-11e7-810e-f37b0af430eb.png)

Note that even when the main repo is owned by `vauxoo` the resulting dependencies are cloned from `oca` (red). Also, note at the end the `getaddons` is returning the addons sorted by dependency level (green).