### PR TITLE
[FIX] travis: Fix sintax error from __future__ imports must occur at the beginning of the file

### DIFF
--- a/travis/git_update.py
+++ b/travis/git_update.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import argparse
 import os
 import re
 import subprocess
-from __future__ import print_function
 
 
 def run_output(l, cwd=None):

--- a/travis/mk_ln_addons.py
+++ b/travis/mk_ln_addons.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-import os
 from __future__ import print_function
+import os
 
 
 def main():

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -43,10 +43,10 @@ Use the following types of pylint configuration files:
 """
 
 
+from __future__ import print_function
 import os
 import re
 import ConfigParser
-from __future__ import print_function
 
 import run_pylint
 import travis_helpers

--- a/travis/travis_weblate.py
+++ b/travis/travis_weblate.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+from __future__ import print_function
 import os
 import re
 import glob
 import subprocess
-from __future__ import print_function
 
 from odoo_connection import Odoo10Context, context_mapping
 from test_server import (get_addons_path, get_server_path, parse_list)


### PR DESCRIPTION
SyntaxError: from __future__ imports must occur at the beginning of the file