### PR TITLE
[FIX] psql_log.py: Change the pg_lo location to /var/log/pg_log

### DIFF
--- a/travis/psql_log.py
+++ b/travis/psql_log.py
@@ -15,7 +15,7 @@ def get_psql_conf_files(psql_conf_path=None):
 
 def get_default_log_path(directory=None, filename=None, root_path=None):
     if directory is None:
-        directory = 'pg_log'
+        directory = '/var/log/pg_log'
     if filename is None:
         filename = 'postgresql.log'
     if root_path is None:

--- a/travis/psql_log.py
+++ b/travis/psql_log.py
@@ -13,13 +13,9 @@ def get_psql_conf_files(psql_conf_path=None):
             yield fname_conf
 
 
-def get_default_log_path(directory=None, filename=None, root_path=None):
-    if directory is None:
-        directory = '/var/log/pg_log'
-    if filename is None:
-        filename = 'postgresql.log'
-    if root_path is None:
-        root_path = '/var/lib/postgresql/*/main*'
+def get_default_log_path(directory='/var/log/pg_log',
+                         filename='postgresql.log',
+                         root_path='/var/lib/postgresql/*/main*'):
     full_path = os.path.join(root_path, directory, filename)
     return [full_path, root_path, directory, filename]
 


### PR DESCRIPTION
Change the pg_log from `/var/lib/postgresql/*/main/pg_log/postgresql.log` to `/var/log/pg_log` because the last one location is the default location of the log of postgres

Related with the follow comment https://github.com/Vauxoo/docker-ubuntu-base/pull/35#discussion_r146012037