### PR TITLE
[IMP] test_flake8: Add suport for $INCLUDE_LINT

### DIFF
--- a/travis/test_flake8
+++ b/travis/test_flake8
@@ -8,14 +8,15 @@ from getaddons import get_modules
 
 root_dir = os.path.dirname(os.path.abspath(__file__))
 flake8_config_dir = os.path.join(root_dir, 'cfg')
+folders = (os.environ.get("INCLUDE_LINT", "").split(",") or
+           get_modules(os.path.abspath('.')))
+exclude = os.environ.get('EXCLUDE_LINT', '').split(',')
 
 status = 0
 
-exclude = os.environ.get('EXCLUDE_LINT', '').split(',')
-modules = [module for module in get_modules(os.path.abspath('.'))
-           if module not in exclude]
-
-for addon in modules:
+for addon in folders:
+    if addon in exclude:
+        continue
     status += subprocess.call(['flake8', addon,
                                '--config=%s/travis_run_flake8__init__.cfg' %
                                flake8_config_dir])


### PR DESCRIPTION
The environment variable `$INCLUDE_LINT` is used in the script
test_pylint, but is not taken into account in this script.

This causes the above variable to be taken into account which modules
will be tested for flake8

This is a port from https://github.com/OCA/maintainer-quality-tools/commit/04c134bce714264fd231e889865baf6bfaca345f