### PR TITLE
[FIX] install: Pinned less@3.0.4

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -36,7 +36,7 @@ fi
 
 # Install less
 ln -s `which nodejs` $HOME/maintainer-quality-tools/travis/node
-npm install -g less less-plugin-clean-css
+npm install -g less@3.0.4 less-plugin-clean-css
 
 if [ "${WEBSITE_REPO}" == "1" ]; then
     if [ -f ~/.rvm/scripts/rvm ]; then
@@ -157,8 +157,6 @@ if [ "x${WITHOUT_DEPENDENCIES}" == "x" ] ; then
     #  Install new dependence: npm package
     wget -qO- https://deb.nodesource.com/setup | sudo bash -
     apt-get install nodejs
-    npm install -g less
-    npm install -g less-plugin-clean-css
 fi
 
 echo "Adding git.vauxoo.com ECDSA key fingerprint"


### PR DESCRIPTION
Version 3.5.1 latest currently is failing compiling
lessc /home/odoo/odoo-11.0/addons/web/static/lib/bootstrap/less/carousel.less --no-js --no-color --include-path=/home/odoo/odoo-11.0/addons/web/static/lib/bootstrap/less
The output is
The "--no-js" argument is deprecated, as inline JavaScript is disabled by default. Use "--js" to enable inline JavaScript (not recommended).
ParseError: Unrecognised input in /home/odoo/odoo-11.0/addons/web/static/lib/bootstrap/less/carousel.less on line 204, column 28:
203     // set alpha transparency for the best results possible.
204     background-color: #000 \9; // IE8
205     background-color: rgba(0,0,0,0); // IE9