### PR TITLE
[IMP] travis_install_nightly: Patch odoo to create unlogged DB tables

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -120,9 +120,9 @@ for file in ${ODOO_PATH}/{odoo,openerp}/addons/base/{base.sql,data/base_data.sql
             ${ODOO_PATH}/{odoo,openerp}/models.py \
             ${ODOO_PATH}/{odoo,openerp}/tools/sql.py
     do
-        if [[ -f ${file} ]] && grep -q "CREATE TABLE" ${file} ; then
+        if [[ -f ${file} ]] && grep -iq "CREATE TABLE" ${file} ; then
             echo -e "\tPatching file '${file}' to create tables as unlogged"
-            sed -i 's/CREATE TABLE/CREATE UNLOGGED TABLE/g' ${file}
+            sed -i 's/CREATE TABLE/CREATE UNLOGGED TABLE/gI' ${file}
         fi
 done
 

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -115,15 +115,15 @@ fi
 
 # Patch Odoo so all database tables are created as unlogged
 echo "Patching Odoo to create all database tables as unlogged"
-for file in {odoo,openerp}/addons/base/{base.sql,data/base_data.sql} \
-            odoo/fields.py \
+for file in {odoo,openerp}/addons/base/base.sql \
+            {odoo,openerp}/fields.py \
             {odoo,openerp}/models.py \
-            odoo/tools/sql.py
-do
-    if [[ -f ${file} ]] && grep -q "CREATE TABLE" ${file} ; then
-        echo -e "\tPatching file ${file}"
-        sed -i 's/CREATE TABLE/CREATE UNLOGGED TABLE/g' ${file}
-    fi
+            {odoo,openerp}/tools/sql.py
+    do
+        if [[ -f ${file} ]] && grep -q "CREATE TABLE" ${file} ; then
+            echo -e "\tPatching file ${file}"
+            sed -i 's/CREATE TABLE/CREATE UNLOGGED TABLE/g' ${file}
+        fi
 done
 
 echo "x${PHANTOMJS_TESTS}"

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -115,7 +115,7 @@ fi
 
 # Patch Odoo so all database tables are created as unlogged
 echo "Patching Odoo to create all database tables as unlogged"
-for file in ${ODOO_PATH}/{odoo,openerp}/addons/base/base.sql \
+for file in ${ODOO_PATH}/{odoo,openerp}/addons/base/{base.sql,data/base_data.sql} \
             ${ODOO_PATH}/{odoo,openerp}/fields.py \
             ${ODOO_PATH}/{odoo,openerp}/models.py \
             ${ODOO_PATH}/{odoo,openerp}/tools/sql.py

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -118,7 +118,8 @@ echo "Patching Odoo to create all database tables as unlogged"
 for file in ${ODOO_PATH}/{odoo,openerp}/addons/base/{base.sql,data/base_data.sql} \
             ${ODOO_PATH}/{odoo,openerp}/fields.py \
             ${ODOO_PATH}/{odoo,openerp}/models.py \
-            ${ODOO_PATH}/{odoo,openerp}/tools/sql.py
+            ${ODOO_PATH}/{odoo,openerp}/tools/sql.py \
+            ${ODOO_PATH}/{odoo,openerp}/osv/orm.py
     do
         if [[ -f ${file} ]] && grep -iq "CREATE TABLE" ${file} ; then
             echo -e "\tPatching file '${file}' to create tables as unlogged"

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -113,6 +113,19 @@ else
     ;
 fi
 
+# Patch Odoo so all database tables are created as unlogged
+echo "Patching Odoo to create all database tables as unlogged"
+for file in {odoo,openerp}/addons/base/{base.sql,data/base_data.sql} \
+            odoo/fields.py \
+            {odoo,openerp}/models.py \
+            odoo/tools/sql.py
+do
+    if [[ -f ${file} ]] && grep -q "CREATE TABLE" ${file} ; then
+        echo -e "\tPatching file ${file}"
+        sed -i 's/CREATE TABLE/CREATE UNLOGGED TABLE/g' ${file}
+    fi
+done
+
 echo "x${PHANTOMJS_TESTS}"
 if [ "x${PHANTOMJS_TESTS}" == "x0" ]; then
     # Disable phantom tests

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -115,10 +115,10 @@ fi
 
 # Patch Odoo so all database tables are created as unlogged
 echo "Patching Odoo to create all database tables as unlogged"
-for file in {odoo,openerp}/addons/base/base.sql \
-            {odoo,openerp}/fields.py \
-            {odoo,openerp}/models.py \
-            {odoo,openerp}/tools/sql.py
+for file in ${ODOO_PATH}/{odoo,openerp}/addons/base/base.sql \
+            ${ODOO_PATH}/{odoo,openerp}/fields.py \
+            ${ODOO_PATH}/{odoo,openerp}/models.py \
+            ${ODOO_PATH}/{odoo,openerp}/tools/sql.py
     do
         if [[ -f ${file} ]] && grep -q "CREATE TABLE" ${file} ; then
             echo -e "\tPatching file ${file}"

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -121,7 +121,7 @@ for file in ${ODOO_PATH}/{odoo,openerp}/addons/base/base.sql \
             ${ODOO_PATH}/{odoo,openerp}/tools/sql.py
     do
         if [[ -f ${file} ]] && grep -q "CREATE TABLE" ${file} ; then
-            echo -e "\tPatching file ${file}"
+            echo -e "\tPatching file '${file}' to create tables as unlogged"
             sed -i 's/CREATE TABLE/CREATE UNLOGGED TABLE/g' ${file}
         fi
 done


### PR DESCRIPTION
This commit causes Odoo to be patched so all database tables are created
as unlogged, just after it's clonned.

This is compatible with the versions 8.0 to master (12.0).

Closes #279