### PR TITLE
[REF] cfg: Rename param manifest_required_author

### DIFF
--- a/travis/cfg/travis_run_pylint.cfg
+++ b/travis/cfg/travis_run_pylint.cfg
@@ -8,7 +8,7 @@ cache-size=500
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_author="Vauxoo"
+manifest_required_authors="Vauxoo"
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
 

--- a/travis/cfg/travis_run_pylint_pr.cfg
+++ b/travis/cfg/travis_run_pylint_pr.cfg
@@ -7,7 +7,7 @@ load-plugins=pylint.extensions.docstyle, pylint.extensions.mccabe
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_author="Vauxoo"
+manifest_required_authors="Vauxoo"
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
 


### PR DESCRIPTION
Since it was renamed on Vauxoo/pylint-odoo@0af4530c34a0, from
`manifest_required_author` to `manifest_required_authors` (from singular
to plural), it needs to be renamed here, too.