### PR TITLE
[REF] test_server: CREATE UNLOGGED TABLE compatible with Odoo >=14.0

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -366,6 +366,7 @@ def patch_odoo_unlogged_tables(server_path):
     filenames_to_patch = [
         'addons/base/base.sql',
         'addons/base/data/base_data.sql',
+        'addons/base/models/res_users.py',
         'fields.py',
         'models.py',
         'tools/sql.py',


### PR DESCRIPTION
Odoo>=14.0 is creating tables from 'addons/base/models/res_users.py'. It was added to the list of files to patch

cc @luistorresm 
Fix https://git.vauxoo.com/vauxoo/grupo-alerta/-/merge_requests/6